### PR TITLE
Add default value for INSTALL_PATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ export DOCKER_TAG ?= latest
 export DOCKER_IMAGE_NAME ?= $(DOCKER_IMAGE):$(DOCKER_TAG)
 export DOCKER_BUILD_FLAGS = 
 export README_DEPS ?= docs/targets.md docs/terraform.md
+export INSTALL_PATH ?= /usr/local/bin
 
 -include $(shell curl -sSL -o .build-harness "https://git.io/build-harness"; echo .build-harness)
 


### PR DESCRIPTION
## what
* Add default value for `INSTALL_PATH`

## why
* On wsl `INSTALL_PATH` defaults to build-harness path